### PR TITLE
[ADD] Better update_sale_order_margin snippet

### DIFF
--- a/update_sale_order_margin.py
+++ b/update_sale_order_margin.py
@@ -1,4 +1,12 @@
-for sale in obj:
+# Action Name:  Update/Fix Sale Order Margin
+# Base Model:   Sales Order
+# Action To Do: Execute Python Code
+# Click button: Add to "More" menu
+
+sales = self.pool["sale.order"].browse(
+    cr, uid, context["active_ids"], context=context)
+
+for sale in sales:
     old_value = sale.margin
     for line in sale.order_line:
         line.write({'purchase_price': line.purchase_price * 1.0})
@@ -11,5 +19,5 @@ for sale in obj:
     else:
         msg = "<ul><li><b>Margin:</b> %(old)s &#8594; %(new)s </li></ul>" % \
             dict(old=old_value, new=sale.margin)
-    self.message_post(cr, uid, object.id, body=msg, type='comment',
+    self.message_post(cr, uid, sale.id, body=msg, type='comment',
                       subject=subject, subtype='html')

--- a/update_sale_order_margin.py
+++ b/update_sale_order_margin.py
@@ -3,21 +3,17 @@
 # Action To Do: Execute Python Code
 # Click button: Add to "More" menu
 
-sales = self.pool["sale.order"].browse(
-    cr, uid, context["active_ids"], context=context)
-
+sales = self.pool["sale.order"].browse(cr, uid, context["active_ids"], context=context)
 for sale in sales:
     old_value = sale.margin
-    for line in sale.order_line:
-        line.write({'purchase_price': line.purchase_price * 1.0})
+    if not sale.order_line:
+        continue
+    
+    sale.order_line[0].write({'purchase_price': sale.order_line[0].purchase_price * 1.0})
     new_value = sale.margin
 
     # Prepare log message
-    subject = "Update/Fix Sale Order Margin server action has been run"
     if old_value == new_value:
-        msg = "Nothing to update, the margin is already updated"
-    else:
-        msg = "<ul><li><b>Margin:</b> %(old)s &#8594; %(new)s </li></ul>" % \
-            dict(old=old_value, new=sale.margin)
-    self.message_post(cr, uid, sale.id, body=msg, type='comment',
-                      subject=subject, subtype='html')
+        continue
+    msg = "<ul><li><b>Margin:</b> %(old)s &#8594; %(new)s </li></ul>" % dict(old=old_value, new=sale.margin)
+    self.message_post(cr, uid, sale.id, body=msg, type='comment', subject="Update/Fix Sale Order Margin server action has been run", subtype='html')


### PR DESCRIPTION
Fixes:
- Use active_ids to take more that one register at time.

Improves
- Use return early methodology to make code lightweight and faster
- Only post message at sale order when the margin has been updated
- Need to update only one sale line, do not need to update all sale lines in order to update the margin